### PR TITLE
invariant double parsing

### DIFF
--- a/src/RedisGraphDotNet.Client/GraphResultSetExtensions.cs
+++ b/src/RedisGraphDotNet.Client/GraphResultSetExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using StackExchange.Redis;
 
@@ -202,6 +203,6 @@ internal static class GraphResultSetExtensions
 
     private static double ParseCommandExecutionTime(string executionTimeString)
     {
-        return double.Parse(executionTimeString.Split(new string[] { "milliseconds"}, StringSplitOptions.RemoveEmptyEntries)[0]);
+        return double.Parse(executionTimeString.Split(new string[] { "milliseconds"}, StringSplitOptions.RemoveEmptyEntries)[0], CultureInfo.InvariantCulture);
     }
 }


### PR DESCRIPTION
ParseCommandExecutionTime is not culture invariant